### PR TITLE
Add compose() for image layer compositing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SMLMRender"
 uuid = "d945b928-cd23-4282-89d9-fc086b52682d"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["klidke@unm.edu"]
 
 [deps]

--- a/api_overview.md
+++ b/api_overview.md
@@ -4,7 +4,7 @@ High-performance rendering for Single Molecule Localization Microscopy (SMLM) da
 
 ## Exports Summary
 
-Total exports: 25 (2 functions, 18 types, 5 utilities)
+Total exports: 26 (2 functions, 18 types, 6 utilities)
 
 **Main Functions:** `render()` - returns `(image, info)` tuple; `api()` - returns API documentation as String
 
@@ -14,7 +14,7 @@ Total exports: 25 (2 functions, 18 types, 5 utilities)
 
 **Render Configuration:** `RenderTarget`, `Image2DTarget`, `ContrastMethod`, `ContrastOptions`, `RenderConfig`, `RenderInfo`, `RenderResult2D` (deprecated)
 
-**Utilities:** `create_target_from_smld`, `list_recommended_colormaps`, `save_image`, `export_colorbar`
+**Utilities:** `create_target_from_smld`, `list_recommended_colormaps`, `save_image`, `export_colorbar`, `compose`
 
 ## Key Concepts
 
@@ -314,6 +314,26 @@ Return dictionary of recommended colormaps organized by category.
 - `:diverging` - For data with meaningful center (RdBu, seismic, coolwarm)
 - `:cyclic` - For periodic data (twilight, phase)
 - `:perceptual` - Perceptually uniform (viridis, cividis, inferno, magma, plasma)
+
+#### `compose(images...; blend=:additive) -> Matrix{RGB{Float64}}`
+
+Composite pre-rendered images into a single image. Decouples compositing from rendering, allowing different strategies per layer.
+
+**Arguments:**
+- `images` - Two or more `Matrix{RGB{Float64}}` images (varargs or Vector)
+- `blend::Symbol` - Blend mode (default: `:additive`)
+  - `:additive` — sum all layers, clamp to [0,1]
+  - `:replace` — later layers overwrite earlier ones where non-black. Best for outline renders (CircleRender, EllipseRender).
+
+**Returns:** `Matrix{RGB{Float64}}` composited image
+
+**Example:**
+```julia
+# Gaussian background + Circle overlay with different strategies
+(bg, _) = render(locs, strategy=GaussianRender(), color=:gray, zoom=20)
+(fg, _) = render(bagol_emitters, strategy=CircleRender(), color=:red, zoom=20)
+combined = compose(bg, fg, blend=:replace)
+```
 
 #### `save_image(filename::String, img::Matrix{RGB}) -> Nothing`
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -67,6 +67,7 @@ create_target_from_smld
 physical_to_pixel
 physical_to_pixel_index
 save_image
+compose
 export_colorbar
 list_recommended_colormaps
 api

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -366,17 +366,19 @@ using Colors
 
 ### Multi-Channel with Different Strategies
 
+Use `compose()` to combine layers rendered with different strategies:
+
 ```julia
-# Note: Currently all channels use same strategy
-# For different strategies per channel, render separately and combine manually
+# Render each channel with its own strategy
+(img1, _) = render(smld1, color=:gray, strategy=GaussianRender(), zoom=20)
+(img2, _) = render(smld2, color=:red, strategy=CircleRender(), zoom=20)
 
-# Render each channel
-(img1, _) = render(smld1, color=:red, strategy=GaussianRender(), zoom=20)
-(img2, _) = render(smld2, color=:green, strategy=CircleRender(), zoom=20)
+# Additive blend (default) — layers sum together
+img_add = compose(img1, img2)
 
-# Manual combination
-img_combined = img1 .+ img2
-save_image("mixed_strategies.png", img_combined)
+# Replace blend — red circles overwrite gray Gaussians where non-black
+img_replace = compose(img1, img2, blend=:replace)
+save_image("mixed_strategies.png", img_replace)
 ```
 
 ## Output and Export

--- a/src/SMLMRender.jl
+++ b/src/SMLMRender.jl
@@ -62,7 +62,7 @@ export render  # Multi-channel via dispatch on Vector{SMLD}
 # Export utilities (may be useful for users)
 export Image2DTarget, create_target_from_smld
 export list_recommended_colormaps
-export save_image
+export save_image, compose
 export export_colorbar
 
 # Export API documentation function

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -418,6 +418,70 @@ function draw_antialiased_point!(img::Matrix{RGB{Float64}}, x::Real, y::Real,
 end
 
 """
+    compose(images::Matrix{RGB{Float64}}...; blend=:additive)
+    compose(images::Vector{Matrix{RGB{Float64}}}; blend=:additive)
+
+Composite pre-rendered images into a single image.
+
+Useful when layers are rendered with different strategies (e.g., Gaussian
+background + Circle overlay) and need to be combined.
+
+# Blend modes
+- `:additive` — sum all layers, clamp to [0,1] (default)
+- `:replace` — later layers overwrite earlier ones where non-black.
+  Best suited for outline renders (CircleRender, EllipseRender) where
+  pixels are either fully drawn or black.
+
+# Examples
+```julia
+# Gaussian locs as background, BaGoL circles on top
+(bg, _) = render(locs, strategy=GaussianRender(), color=:gray, zoom=20)
+(fg, _) = render(bagol, strategy=CircleRender(), color=:red, zoom=20)
+combined = compose(bg, fg, blend=:replace)
+```
+"""
+function compose(images::Matrix{RGB{Float64}}...; blend::Symbol=:additive)
+    return compose(collect(images); blend=blend)
+end
+
+function compose(images::Vector{Matrix{RGB{Float64}}}; blend::Symbol=:additive)
+    @assert !isempty(images) "Must provide at least one image"
+    @assert blend in (:additive, :replace) "blend must be :additive or :replace"
+
+    sz = size(images[1])
+    for img in images
+        @assert size(img) == sz "All images must have the same dimensions"
+    end
+
+    combined = zeros(RGB{Float64}, sz)
+
+    if blend == :additive
+        for img in images
+            combined .+= img
+        end
+    else  # :replace
+        for img in images
+            @inbounds for i in eachindex(combined)
+                px = img[i]
+                if px.r > 0 || px.g > 0 || px.b > 0
+                    combined[i] = px
+                end
+            end
+        end
+    end
+
+    # Clamp to [0, 1]
+    @inbounds for i in eachindex(combined)
+        px = combined[i]
+        combined[i] = RGB(clamp(px.r, 0.0, 1.0),
+                          clamp(px.g, 0.0, 1.0),
+                          clamp(px.b, 0.0, 1.0))
+    end
+
+    return combined
+end
+
+"""
     save_image(filename::String, img::Matrix{RGB})
 
 Save rendered image directly to file.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -302,4 +302,36 @@ end
         @test result[2] isa RenderInfo
     end
 
+    @testset "compose" begin
+        # Create two small test images
+        bg = fill(RGB{Float64}(0.5, 0.5, 0.5), 10, 10)
+        bg[1, 1] = RGB{Float64}(0.0, 0.0, 0.0)  # black pixel
+
+        fg = zeros(RGB{Float64}, 10, 10)
+        fg[5, 5] = RGB{Float64}(1.0, 0.0, 0.0)  # red pixel
+
+        # Additive blend
+        added = compose(bg, fg, blend=:additive)
+        @test added[5, 5] ≈ RGB{Float64}(1.0, 0.5, 0.5)  # gray + red
+        @test added[1, 1] ≈ RGB{Float64}(0.0, 0.0, 0.0)  # bg was black here, fg is zero → stays black
+
+        # Replace blend — non-black fg pixels overwrite
+        replaced = compose(bg, fg, blend=:replace)
+        @test replaced[5, 5] ≈ RGB{Float64}(1.0, 0.0, 0.0)  # red replaces gray
+        @test replaced[3, 3] ≈ RGB{Float64}(0.5, 0.5, 0.5)  # no fg, keeps bg
+
+        # Replace with black fg pixel — should NOT overwrite
+        @test replaced[1, 1] ≈ RGB{Float64}(0.0, 0.0, 0.0)  # bg was black, fg absent → stays black
+
+        # Vector form
+        vec_result = compose([bg, fg], blend=:replace)
+        @test vec_result == replaced
+
+        # Dimension mismatch
+        @test_throws AssertionError compose(bg, zeros(RGB{Float64}, 5, 5))
+
+        # Invalid blend mode
+        @test_throws AssertionError compose(bg, fg, blend=:invalid)
+    end
+
 end


### PR DESCRIPTION
## Summary

- Adds `compose(images...; blend=:additive)` utility for compositing pre-rendered images
- Two blend modes: `:additive` (sum, clamp) and `:replace` (later non-black pixels overwrite)
- Decouples compositing from rendering — enables mixed-strategy overlays (e.g., Gaussian background + Circle overlay)
- Motivated by BaGoL use case: gray localizations + red BaGoL emitters where additive blending washes out the overlay

## Usage

```julia
(bg, _) = render(locs, strategy=GaussianRender(), color=:gray, zoom=20)
(fg, _) = render(bagol, strategy=CircleRender(), color=:red, zoom=20)
combined = compose(bg, fg, blend=:replace)
```

## Changes

- `src/utils.jl` — `compose()` implementation (varargs + Vector forms)
- `src/SMLMRender.jl` — export `compose`
- `test/runtests.jl` — tests for both blend modes, dimension mismatch, invalid mode
- `api_overview.md`, `docs/src/api.md`, `docs/src/examples.md` — documentation

## Test plan

- [x] All 80 tests pass
- [x] Additive blend sums layers and clamps
- [x] Replace blend overwrites non-black pixels, preserves black
- [x] Vector and varargs forms produce identical results
- [x] Assertion errors for dimension mismatch and invalid blend mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)