### PR TITLE
Render categorical id 0 as gray (v0.4.3)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SMLMRender"
 uuid = "d945b928-cd23-4282-89d9-fc086b52682d"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["klidke@unm.edu"]
 
 [deps]

--- a/src/color/mapping.jl
+++ b/src/color/mapping.jl
@@ -184,11 +184,29 @@ function get_emitter_color(emitter, mapping::GrayscaleMapping; value_range=nothi
     return RGB{Float64}(1.0, 1.0, 1.0)
 end
 
+# Color used for the reserved categorical id 0 (e.g. unclustered/background)
+const CATEGORICAL_ZERO_COLOR = RGB{Float64}(0.5, 0.5, 0.5)
+
+"""
+    categorical_color(int_value::Integer, palette, n_colors::Integer)
+
+Map an integer category to an RGB color. An id of `0` renders as gray
+(`CATEGORICAL_ZERO_COLOR`), reserved for unclustered/background localizations.
+All other values use modular indexing into `palette`, so colors cycle for
+values exceeding the palette size.
+"""
+function categorical_color(int_value::Integer, palette, n_colors::Integer)
+    int_value == 0 && return CATEGORICAL_ZERO_COLOR
+    idx = mod1(int_value, n_colors)
+    return RGB{Float64}(palette[idx])
+end
+
 """
     get_emitter_color(emitter, mapping::CategoricalColorMapping; kwargs...)
 
-Get categorical color for emitter based on integer field value.
-Uses modular indexing into palette - colors cycle for values > palette size.
+Get categorical color for emitter based on integer field value. An id of `0`
+renders as gray; all other values use modular palette indexing so colors cycle
+for values exceeding the palette size.
 """
 function get_emitter_color(emitter, mapping::CategoricalColorMapping; kwargs...)
     # Get integer field value
@@ -199,10 +217,7 @@ function get_emitter_color(emitter, mapping::CategoricalColorMapping; kwargs...)
     palette = get_colormap(mapping.palette)
     n_colors = length(palette)
 
-    # Modular index (1-based)
-    idx = mod1(int_value, n_colors)
-
-    return RGB{Float64}(palette[idx])
+    return categorical_color(int_value, palette, n_colors)
 end
 
 """

--- a/src/render/histogram.jl
+++ b/src/render/histogram.jl
@@ -219,11 +219,10 @@ function render_histogram_categorical(smld, target::Image2DTarget,
     for emitter in smld.emitters
         i, j = physical_to_pixel_index(emitter.x, emitter.y, target)
         if in_bounds(i, j, target)
-            # Get categorical color
+            # Get categorical color (id 0 renders as gray)
             value = getfield(emitter, mapping.field)
             int_value = round(Int, value)
-            idx = mod1(int_value, n_colors)
-            color = RGB{Float64}(palette[idx])
+            color = categorical_color(int_value, palette, n_colors)
 
             # Accumulate color components and count
             r_sum[i, j] += color.r

--- a/src/types.jl
+++ b/src/types.jl
@@ -287,8 +287,10 @@ struct GrayscaleMapping <: ColorMapping end
 """
     CategoricalColorMapping <: ColorMapping
 
-Color localizations by integer field using categorical palette. Colors cycle
-when values exceed palette size. Ideal for cluster IDs, molecule IDs, etc.
+Color localizations by integer field using categorical palette. An id of `0`
+renders as gray (reserved for unclustered/background localizations); all other
+values cycle through the palette when they exceed its size. Ideal for cluster
+IDs, molecule IDs, etc.
 
 # Fields
 - `field::Symbol`: Integer field name (:id, :cluster_id, :molecule, etc.)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,6 +126,23 @@ end
         @test info_manual.color_mode == :manual
     end
 
+    @testset "Categorical id 0 renders as gray" begin
+        palette = SMLMRender.get_colormap(:tab10)
+        n = length(palette)
+
+        # id 0 is reserved for unclustered/background -> fixed gray
+        @test SMLMRender.categorical_color(0, palette, n) == SMLMRender.CATEGORICAL_ZERO_COLOR
+        @test SMLMRender.categorical_color(0, palette, n) == RGB{Float64}(0.5, 0.5, 0.5)
+
+        # Positive ids use the palette (and are not the gray)
+        @test SMLMRender.categorical_color(1, palette, n) != SMLMRender.CATEGORICAL_ZERO_COLOR
+        @test SMLMRender.categorical_color(1, palette, n) == RGB{Float64}(palette[1])
+
+        # Cycling intact for values beyond palette size
+        @test SMLMRender.categorical_color(n + 1, palette, n) ==
+              SMLMRender.categorical_color(1, palette, n)
+    end
+
     @testset "Field range in RenderInfo" begin
         camera = IdealCamera(32, 32, 100.0)
         emitters = [


### PR DESCRIPTION
## Summary

Reserve categorical id `0` for unclustered/background localizations, rendering it as a fixed mid-gray `RGB(0.5, 0.5, 0.5)`. All other values continue to cycle through the named palette via modular indexing.

This lets a single `CategoricalColorMapping` render distinguish noise (id 0 → gray) from clusters (ids 1..K → palette) in one pass — previously this required a two-pass render + manual RGB compositing.

## Changes

- `src/color/mapping.jl` — add `CATEGORICAL_ZERO_COLOR` const and a shared `categorical_color(int_value, palette, n_colors)` helper (`0 → gray`, else `mod1` cycling). `get_emitter_color(::CategoricalColorMapping)` delegates to it (covers gaussian/circle/ellipse strategies).
- `src/render/histogram.jl` — use the shared helper instead of inlined indexing, so histogram gets the same behavior.
- `src/types.jl` — document the `0 → gray` reservation on `CategoricalColorMapping`.
- `test/runtests.jl` — assert id 0 = gray, positive ids map to palette, cycling intact.
- `Project.toml` — bump 0.4.2 → 0.4.3.

## API / compatibility

- **No API change**: no new/removed exports, no changed signatures or types. `CategoricalColorMapping(field, palette)` is unchanged.
- **One behavior change**: previously `id 0` rendered as `palette[mod1(0,10)]` (the last palette color); it now renders gray. Existing renders containing `id 0` localizations will change appearance.
- Bumped as a **patch** (0.4.3): no API surface change, and the prior id-0 color was an incidental `mod1` wraparound rather than intended behavior.

## Testing

Full suite passes: 85/85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)