### PR TITLE
Skip gray-like palette colors for categorical clusters (v0.4.4)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SMLMRender"
 uuid = "d945b928-cd23-4282-89d9-fc086b52682d"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["klidke@unm.edu"]
 
 [deps]

--- a/src/color/mapping.jl
+++ b/src/color/mapping.jl
@@ -187,17 +187,48 @@ end
 # Color used for the reserved categorical id 0 (e.g. unclustered/background)
 const CATEGORICAL_ZERO_COLOR = RGB{Float64}(0.5, 0.5, 0.5)
 
+# A palette entry is treated as "gray-like" (and skipped for positive cluster
+# ids) when its chroma is below this tolerance. This keeps clusters from being
+# colored in a shade that collides with the reserved id-0 gray — e.g. tab10's
+# 8th color is (0.498, 0.498, 0.498), nearly identical to CATEGORICAL_ZERO_COLOR.
+const CATEGORICAL_GRAY_CHROMA_TOL = 0.1
+
 """
-    categorical_color(int_value::Integer, palette, n_colors::Integer)
+    is_gray_like(c) -> Bool
+
+True if a color is approximately achromatic (low chroma), i.e. close to a gray.
+Used to exclude palette entries that would collide with the reserved id-0 gray.
+"""
+function is_gray_like(c)
+    rgb = RGB{Float64}(c)
+    return (max(rgb.r, rgb.g, rgb.b) - min(rgb.r, rgb.g, rgb.b)) < CATEGORICAL_GRAY_CHROMA_TOL
+end
+
+"""
+    categorical_palette(name::Symbol) -> Vector{RGB{Float64}}
+
+Return the named palette with gray-like entries removed, so positive category
+ids never render in a shade that collides with the reserved id-0 gray. Falls
+back to the full palette if every entry is gray-like.
+"""
+function categorical_palette(name::Symbol)
+    full = RGB{Float64}[RGB{Float64}(c) for c in get_colormap(name)]
+    filtered = filter(!is_gray_like, full)
+    return isempty(filtered) ? full : filtered
+end
+
+"""
+    categorical_color(int_value::Integer, palette::AbstractVector)
 
 Map an integer category to an RGB color. An id of `0` renders as gray
 (`CATEGORICAL_ZERO_COLOR`), reserved for unclustered/background localizations.
-All other values use modular indexing into `palette`, so colors cycle for
-values exceeding the palette size.
+All other values cycle through `palette` via modular indexing — `palette`
+should already have gray-like entries removed (see [`categorical_palette`](@ref))
+so no cluster collides with the reserved gray.
 """
-function categorical_color(int_value::Integer, palette, n_colors::Integer)
+function categorical_color(int_value::Integer, palette::AbstractVector)
     int_value == 0 && return CATEGORICAL_ZERO_COLOR
-    idx = mod1(int_value, n_colors)
+    idx = mod1(int_value, length(palette))
     return RGB{Float64}(palette[idx])
 end
 
@@ -205,19 +236,18 @@ end
     get_emitter_color(emitter, mapping::CategoricalColorMapping; kwargs...)
 
 Get categorical color for emitter based on integer field value. An id of `0`
-renders as gray; all other values use modular palette indexing so colors cycle
-for values exceeding the palette size.
+renders as gray; all other values cycle through the palette (with gray-like
+entries skipped) so colors cycle for values exceeding the palette size.
 """
 function get_emitter_color(emitter, mapping::CategoricalColorMapping; kwargs...)
     # Get integer field value
     value = getfield(emitter, mapping.field)
     int_value = round(Int, value)
 
-    # Get palette
-    palette = get_colormap(mapping.palette)
-    n_colors = length(palette)
+    # Palette with gray-like entries removed (avoids cluster/noise color clash)
+    palette = categorical_palette(mapping.palette)
 
-    return categorical_color(int_value, palette, n_colors)
+    return categorical_color(int_value, palette)
 end
 
 """

--- a/src/render/histogram.jl
+++ b/src/render/histogram.jl
@@ -206,9 +206,8 @@ the most frequent cluster's color (mode).
 function render_histogram_categorical(smld, target::Image2DTarget,
                                       mapping::CategoricalColorMapping;
                                       clip_percentile::Union{Float64, Nothing}=0.99)
-    # Get palette
-    palette = get_colormap(mapping.palette)
-    n_colors = length(palette)
+    # Palette with gray-like entries removed (avoids cluster/noise color clash)
+    palette = categorical_palette(mapping.palette)
 
     # Track color component sums and counts per pixel
     r_sum = zeros(Float64, target.height, target.width)
@@ -222,7 +221,7 @@ function render_histogram_categorical(smld, target::Image2DTarget,
             # Get categorical color (id 0 renders as gray)
             value = getfield(emitter, mapping.field)
             int_value = round(Int, value)
-            color = categorical_color(int_value, palette, n_colors)
+            color = categorical_color(int_value, palette)
 
             # Accumulate color components and count
             r_sum[i, j] += color.r

--- a/src/types.jl
+++ b/src/types.jl
@@ -289,8 +289,9 @@ struct GrayscaleMapping <: ColorMapping end
 
 Color localizations by integer field using categorical palette. An id of `0`
 renders as gray (reserved for unclustered/background localizations); all other
-values cycle through the palette when they exceed its size. Ideal for cluster
-IDs, molecule IDs, etc.
+values cycle through the palette when they exceed its size. Gray-like palette
+entries (e.g. tab10's 8th color) are skipped for positive ids so no cluster
+collides with the reserved gray. Ideal for cluster IDs, molecule IDs, etc.
 
 # Fields
 - `field::Symbol`: Integer field name (:id, :cluster_id, :molecule, etc.)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,20 +127,28 @@ end
     end
 
     @testset "Categorical id 0 renders as gray" begin
-        palette = SMLMRender.get_colormap(:tab10)
+        palette = SMLMRender.categorical_palette(:tab10)
         n = length(palette)
 
         # id 0 is reserved for unclustered/background -> fixed gray
-        @test SMLMRender.categorical_color(0, palette, n) == SMLMRender.CATEGORICAL_ZERO_COLOR
-        @test SMLMRender.categorical_color(0, palette, n) == RGB{Float64}(0.5, 0.5, 0.5)
+        @test SMLMRender.categorical_color(0, palette) == SMLMRender.CATEGORICAL_ZERO_COLOR
+        @test SMLMRender.categorical_color(0, palette) == RGB{Float64}(0.5, 0.5, 0.5)
 
         # Positive ids use the palette (and are not the gray)
-        @test SMLMRender.categorical_color(1, palette, n) != SMLMRender.CATEGORICAL_ZERO_COLOR
-        @test SMLMRender.categorical_color(1, palette, n) == RGB{Float64}(palette[1])
+        @test SMLMRender.categorical_color(1, palette) != SMLMRender.CATEGORICAL_ZERO_COLOR
+        @test SMLMRender.categorical_color(1, palette) == RGB{Float64}(palette[1])
 
         # Cycling intact for values beyond palette size
-        @test SMLMRender.categorical_color(n + 1, palette, n) ==
-              SMLMRender.categorical_color(1, palette, n)
+        @test SMLMRender.categorical_color(n + 1, palette) ==
+              SMLMRender.categorical_color(1, palette)
+
+        # Gray-like palette entries are filtered out: tab10's 8th color is
+        # (0.498,0.498,0.498), which would collide with the noise gray.
+        @test n == length(SMLMRender.get_colormap(:tab10)) - 1
+        @test !any(SMLMRender.is_gray_like, palette)
+        # No positive cluster id (full cycle) ever renders gray-like
+        @test all(!SMLMRender.is_gray_like(SMLMRender.categorical_color(k, palette))
+                  for k in 1:n)
     end
 
     @testset "Field range in RenderInfo" begin


### PR DESCRIPTION
## Summary

Fixes a color collision in categorical rendering: the reserved id-0 noise gray `RGB(0.5, 0.5, 0.5)` clashed with achromatic palette entries used for clusters. Most importantly, **tab10's 8th color is `(0.498, 0.498, 0.498)`** — so with the default palette, cluster id 8 (and 18, 28, … via cycling) rendered identically to noise. Follow-up to #19.

## Fix

- Add `is_gray_like` (chroma < `0.1`) and `categorical_palette(name)`, which returns the named palette with gray-like entries removed.
- Positive cluster ids cycle through the *filtered* palette, so no cluster is ever colored like the reserved noise gray. id 0 still maps to the fixed gray.
- Falls back to the full palette if every entry is gray-like (defensive; won't happen for real palettes).

## Affected palettes

Gray-like entries now skipped for clusters: `tab10` #8, `tab20` #15, `tab20c` #17/#18, `Set1_9` #9. Real colors (e.g. `tab20b`'s olive) are untouched.

## Compatibility

- **No API change.** `CategoricalColorMapping(field, palette)` unchanged.
- **Behavior change** (intended): cluster ids that previously landed on a gray palette slot now render a non-gray color, and the cycle length for `tab10` is 9 instead of 10.
- Patch bump 0.4.3 → 0.4.4.

## Testing

Full suite passes: 88/88, including assertions that tab10's filtered palette has no gray-like entry and that no positive id over a full cycle renders gray-like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)