### PR TITLE
Hoist categorical palette out of per-emitter render loops (v0.4.5)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SMLMRender"
 uuid = "d945b928-cd23-4282-89d9-fc086b52682d"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["klidke@unm.edu"]
 
 [deps]

--- a/src/color/mapping.jl
+++ b/src/color/mapping.jl
@@ -239,15 +239,19 @@ Get categorical color for emitter based on integer field value. An id of `0`
 renders as gray; all other values cycle through the palette (with gray-like
 entries skipped) so colors cycle for values exceeding the palette size.
 """
-function get_emitter_color(emitter, mapping::CategoricalColorMapping; kwargs...)
+function get_emitter_color(emitter, mapping::CategoricalColorMapping;
+                           palette::Union{AbstractVector, Nothing}=nothing, kwargs...)
     # Get integer field value
     value = getfield(emitter, mapping.field)
     int_value = round(Int, value)
 
-    # Palette with gray-like entries removed (avoids cluster/noise color clash)
-    palette = categorical_palette(mapping.palette)
+    # Palette with gray-like entries removed (avoids cluster/noise color clash).
+    # Prefer a caller-supplied palette built once per render — rebuilding it here
+    # reallocates the palette for every emitter (see the render_*_categorical
+    # loops, which hoist it out and pass it in, mirroring the field `lut`).
+    _palette = palette !== nothing ? palette : categorical_palette(mapping.palette)
 
-    return categorical_color(int_value, palette)
+    return categorical_color(int_value, _palette)
 end
 
 """

--- a/src/render/circle.jl
+++ b/src/render/circle.jl
@@ -111,6 +111,9 @@ function render_circle_categorical(smld, target::Image2DTarget,
                                    mapping::CategoricalColorMapping)
     result = zeros(RGB{Float64}, target.height, target.width)
 
+    # Build the palette once, not per emitter (see get_emitter_color).
+    palette = categorical_palette(mapping.palette)
+
     for emitter in smld.emitters
         radius_nm = get_emitter_radius(emitter, strategy)
 
@@ -119,7 +122,7 @@ function render_circle_categorical(smld, target::Image2DTarget,
         end
 
         # Get categorical color
-        color = get_emitter_color(emitter, mapping)
+        color = get_emitter_color(emitter, mapping; palette=palette)
 
         draw_circle_outline!(result, emitter, target, radius_nm,
                            color, strategy.line_width)

--- a/src/render/ellipse.jl
+++ b/src/render/ellipse.jl
@@ -112,6 +112,9 @@ function render_ellipse_categorical(smld, target::Image2DTarget,
                                     mapping::CategoricalColorMapping)
     result = zeros(RGB{Float64}, target.height, target.width)
 
+    # Build the palette once, not per emitter (see get_emitter_color).
+    palette = categorical_palette(mapping.palette)
+
     for emitter in smld.emitters
         radius_x_nm, radius_y_nm, θ = get_ellipse_params(emitter, strategy)
 
@@ -121,7 +124,7 @@ function render_ellipse_categorical(smld, target::Image2DTarget,
         end
 
         # Get categorical color
-        color = get_emitter_color(emitter, mapping)
+        color = get_emitter_color(emitter, mapping; palette=palette)
 
         draw_ellipse_outline!(result, emitter, target, radius_x_nm, radius_y_nm, θ,
                              color, strategy.line_width)

--- a/src/render/gaussian.jl
+++ b/src/render/gaussian.jl
@@ -194,6 +194,9 @@ function render_gaussian_categorical(smld, target::Image2DTarget,
     g_num = zeros(Float64, target.height, target.width)
     b_num = zeros(Float64, target.height, target.width)
 
+    # Build the palette once, not per emitter (see get_emitter_color).
+    palette = categorical_palette(mapping.palette)
+
     for emitter in smld.emitters
         # Get covariance values
         sigma_x, sigma_y, sigma_xy = get_emitter_covariance(emitter, strategy)
@@ -203,7 +206,7 @@ function render_gaussian_categorical(smld, target::Image2DTarget,
         end
 
         # Get categorical color for this emitter
-        color = get_emitter_color(emitter, mapping)
+        color = get_emitter_color(emitter, mapping; palette=palette)
 
         # Render blob, accumulating both intensity and color
         render_gaussian_blob_weighted!(intensity, r_num, g_num, b_num,


### PR DESCRIPTION
**Draft — perf fix.** Independent of #21 (empty-loc). Both bump to 0.4.5, so whichever merges second needs a one-line bump to 0.4.6.

## Problem
`render_{ellipse,circle,gaussian}_categorical` called `get_emitter_color(::CategoricalColorMapping)` **per emitter**, which rebuilt the entire categorical palette every call (`categorical_palette` → colormap dict lookup + 2 vector allocs + `filter`). That's ~1408 B and a colormap rebuild **per localization**. `render_histogram_categorical` already hoisted it; the three outline/blob paths did not.

## Fix
- Add a `palette` kwarg to `get_emitter_color(::CategoricalColorMapping)`, mirroring the field path's `lut`.
- Build the palette **once per render** and pass it into the loop.

Output is unchanged: `categorical_palette` is a pure function of its `Symbol`, so build-once == build-per-emitter (verified `==` and by the existing categorical tests).

## Speed comparison
N=20000 emitters, 512×512 output, min of 30 runs, 1 thread:

| case | before | after | speedup | alloc before→after |
|---|---|---|---|---|
| gaussian categorical | 56.98 ms | 22.64 ms | **2.5×** | 47.8 → 21.0 MiB |
| circle categorical | 39.61 ms | 7.29 ms | **5.4×** | 32.9 → 6.0 MiB |
| ellipse categorical | 42.49 ms | 10.55 ms | **4.0×** | 32.9 → 6.0 MiB |
| ellipse manual (control) | 10.46 ms | 10.31 ms | unchanged | 6.0 MiB |

Circle/ellipse benefit most (cheap draw → palette rebuild was dominant); ellipse categorical now matches its manual control. Per-emitter allocation eliminated — remaining MiB is the output/accumulator buffers.

## Tests
Full suite: **88/88 pass** (categorical correctness unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)