### PR TITLE
Release v0.4.6: empty/few-loc robustness + categorical perf

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SMLMRender"
 uuid = "d945b928-cd23-4282-89d9-fc086b52682d"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["klidke@unm.edu"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SMLMRender"
 uuid = "d945b928-cd23-4282-89d9-fc086b52682d"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["klidke@unm.edu"]
 
 [deps]

--- a/src/color/mapping.jl
+++ b/src/color/mapping.jl
@@ -102,7 +102,10 @@ function apply_intensity_colormap(intensity::Matrix{Float64}, mapping::Intensity
     result = Matrix{RGB{Float64}}(undef, size(intensity))
 
     if max_val ≈ min_val
-        fill_color = colormap_lookup(lut, 0.5)
+        # Uniform range: all-zero (empty / no signal) maps to the colormap's
+        # zero end so the image is blank; uniform non-zero signal maps to
+        # mid-colormap so it stays visible.
+        fill_color = colormap_lookup(lut, iszero(max_val) ? 0.0 : 0.5)
         @inbounds for i in eachindex(result)
             result[i] = fill_color
         end

--- a/src/color/mapping.jl
+++ b/src/color/mapping.jl
@@ -239,15 +239,19 @@ Get categorical color for emitter based on integer field value. An id of `0`
 renders as gray; all other values cycle through the palette (with gray-like
 entries skipped) so colors cycle for values exceeding the palette size.
 """
-function get_emitter_color(emitter, mapping::CategoricalColorMapping; kwargs...)
+function get_emitter_color(emitter, mapping::CategoricalColorMapping;
+                           palette::Union{AbstractVector, Nothing}=nothing, kwargs...)
     # Get integer field value
     value = getfield(emitter, mapping.field)
     int_value = round(Int, value)
 
-    # Palette with gray-like entries removed (avoids cluster/noise color clash)
-    palette = categorical_palette(mapping.palette)
+    # Palette with gray-like entries removed (avoids cluster/noise color clash).
+    # Prefer a caller-supplied palette built once per render — rebuilding it here
+    # reallocates the palette for every emitter (see the render_*_categorical
+    # loops, which hoist it out and pass it in, mirroring the field `lut`).
+    _palette = palette !== nothing ? palette : categorical_palette(mapping.palette)
 
-    return categorical_color(int_value, palette)
+    return categorical_color(int_value, _palette)
 end
 
 """

--- a/src/render/circle.jl
+++ b/src/render/circle.jl
@@ -111,6 +111,9 @@ function render_circle_categorical(smld, target::Image2DTarget,
                                    mapping::CategoricalColorMapping)
     result = zeros(RGB{Float64}, target.height, target.width)
 
+    # Build the palette once, not per emitter (see get_emitter_color).
+    palette = categorical_palette(mapping.palette)
+
     for emitter in smld.emitters
         radius_nm = get_emitter_radius(emitter, strategy)
 
@@ -119,7 +122,7 @@ function render_circle_categorical(smld, target::Image2DTarget,
         end
 
         # Get categorical color
-        color = get_emitter_color(emitter, mapping)
+        color = get_emitter_color(emitter, mapping; palette=palette)
 
         draw_circle_outline!(result, emitter, target, radius_nm,
                            color, strategy.line_width)

--- a/src/render/ellipse.jl
+++ b/src/render/ellipse.jl
@@ -112,6 +112,9 @@ function render_ellipse_categorical(smld, target::Image2DTarget,
                                     mapping::CategoricalColorMapping)
     result = zeros(RGB{Float64}, target.height, target.width)
 
+    # Build the palette once, not per emitter (see get_emitter_color).
+    palette = categorical_palette(mapping.palette)
+
     for emitter in smld.emitters
         radius_x_nm, radius_y_nm, θ = get_ellipse_params(emitter, strategy)
 
@@ -121,7 +124,7 @@ function render_ellipse_categorical(smld, target::Image2DTarget,
         end
 
         # Get categorical color
-        color = get_emitter_color(emitter, mapping)
+        color = get_emitter_color(emitter, mapping; palette=palette)
 
         draw_ellipse_outline!(result, emitter, target, radius_x_nm, radius_y_nm, θ,
                              color, strategy.line_width)

--- a/src/render/gaussian.jl
+++ b/src/render/gaussian.jl
@@ -194,6 +194,9 @@ function render_gaussian_categorical(smld, target::Image2DTarget,
     g_num = zeros(Float64, target.height, target.width)
     b_num = zeros(Float64, target.height, target.width)
 
+    # Build the palette once, not per emitter (see get_emitter_color).
+    palette = categorical_palette(mapping.palette)
+
     for emitter in smld.emitters
         # Get covariance values
         sigma_x, sigma_y, sigma_xy = get_emitter_covariance(emitter, strategy)
@@ -203,7 +206,7 @@ function render_gaussian_categorical(smld, target::Image2DTarget,
         end
 
         # Get categorical color for this emitter
-        color = get_emitter_color(emitter, mapping)
+        color = get_emitter_color(emitter, mapping; palette=palette)
 
         # Render blob, accumulating both intensity and color
         render_gaussian_blob_weighted!(intensity, r_num, g_num, b_num,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -181,23 +181,39 @@ function create_target_from_smld(smld; pixel_size=nothing, zoom=nothing, roi=not
     # Mode 2: pixel_size specified - use data bounds + margin
     else
         emitters = smld.emitters
-        x_coords = [e.x for e in emitters]
-        y_coords = [e.y for e in emitters]
 
-        x_min, x_max = extrema(x_coords)
-        y_min, y_max = extrema(y_coords)
+        if isempty(emitters)
+            # No localizations → no data bounds. Center a minimal blank image at
+            # the origin so render() returns a valid (blank) image instead of
+            # crashing on `extrema` of an empty collection.
+            x_min = x_max = y_min = y_max = 0.0
+        else
+            x_coords = [e.x for e in emitters]
+            y_coords = [e.y for e in emitters]
 
-        # Add margin
-        x_span = x_max - x_min
-        y_span = y_max - y_min
-        x_min -= margin * x_span
-        x_max += margin * x_span
-        y_min -= margin * y_span
-        y_max += margin * y_span
+            x_min, x_max = extrema(x_coords)
+            y_min, y_max = extrema(y_coords)
+        end
+
+        # Floor each span at one pixel so empty / single / coincident data still
+        # yields a positive-size image with a valid (min < max) range instead of
+        # a zero-dimension AssertionError. For data spanning ≥ 1 pixel this is a
+        # no-op and the bounds below reproduce the original margin computation.
+        one_px_um = pixel_size / 1000
+        x_span = max(x_max - x_min, one_px_um)
+        y_span = max(y_max - y_min, one_px_um)
+
+        # Bounds centered on the data, expanded by the fractional margin.
+        x_mid = (x_min + x_max) / 2
+        y_mid = (y_min + y_max) / 2
+        x_min = x_mid - x_span * (0.5 + margin)
+        x_max = x_mid + x_span * (0.5 + margin)
+        y_min = y_mid - y_span * (0.5 + margin)
+        y_max = y_mid + y_span * (0.5 + margin)
 
         # Calculate image dimensions
-        width = ceil(Int, (x_max - x_min) * 1000 / pixel_size)
-        height = ceil(Int, (y_max - y_min) * 1000 / pixel_size)
+        width = max(1, ceil(Int, (x_max - x_min) * 1000 / pixel_size))
+        height = max(1, ceil(Int, (y_max - y_min) * 1000 / pixel_size))
     end
 
     return Image2DTarget(width, height, pixel_size, (x_min, x_max), (y_min, y_max))
@@ -236,6 +252,10 @@ function calculate_field_range(smld, field::Symbol, clip_percentiles; frame_offs
     if field === :absolute_frame && frame_offsets === nothing
         frame_offsets = compute_frame_offsets(smld)
     end
+
+    # No localizations → no field values to reduce over. Return a default unit
+    # range so downstream colormap normalization stays valid (image is blank).
+    isempty(smld.emitters) && return (0.0, 1.0)
 
     values = [get_field_value(e, field; frame_offsets=frame_offsets) for e in smld.emitters]
 
@@ -301,7 +321,9 @@ function normalize_to_01(img::Matrix{T}) where T<:Real
     max_val = maximum(img)
 
     if max_val ≈ min_val
-        return fill(T(0.5), size(img))
+        # Uniform image: all-zero (no signal, e.g. empty input) stays blank;
+        # uniform non-zero signal maps to mid-level so it stays visible.
+        return fill(iszero(max_val) ? zero(T) : T(0.5), size(img))
     end
 
     scale = one(T) / (max_val - min_val)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -359,4 +359,72 @@ end
         @test_throws AssertionError compose(bg, fg, blend=:invalid)
     end
 
+    @testset "Empty and few-localization robustness" begin
+        # Regression: render() must not crash on 0 or 1-2 localizations and must
+        # return a valid image (blank for empty) across every
+        # strategy × color-mode × resolution-mode combination. Previously empty
+        # input crashed in reductions (extrema/quantile over empty values,
+        # zero-span target bounds) and tiny inputs hit a 0-dimension target.
+        cam = IdealCamera(32, 32, 100.0)
+
+        # SMLD with n emitters (n=0 → typed-empty vector).
+        make_n(n) = BasicSMLD(
+            n == 0 ? Emitter2DFit{Float64}[] :
+                     [make_emitter2d(3.0 + 0.05k, 3.0 + 0.05k, 1000.0, 10.0,
+                                     0.02, 0.02, 50.0, 2.0; frame=1, id=k)
+                      for k in 1:n],
+            cam, 1, 1)
+
+        # color-mode label => render kwargs
+        intensity   = (:intensity,   (; colormap=:inferno))
+        field       = (:field,       (; color_by=:photons))
+        categorical = (:categorical, (; color_by=:id, categorical=true))
+        manual      = (:manual,      (; color=:red))
+
+        # Circle/Ellipse don't support the intensity colormap.
+        strategies = [
+            (:gaussian,  GaussianRender(),  [intensity, field, categorical, manual]),
+            (:histogram, HistogramRender(), [intensity, field, categorical, manual]),
+            (:circle,    CircleRender(),    [field, categorical, manual]),
+            (:ellipse,   EllipseRender(),   [field, categorical, manual]),
+        ]
+
+        for (sname, strat, modes) in strategies, (cname, ckw) in modes,
+            resmode in (:zoom, :pixel_size), n in (0, 1, 2)
+
+            rkw = resmode === :zoom ? (; zoom=5) : (; pixel_size=100.0)
+
+            # Must not throw for 0, 1, or 2 localizations.
+            img = nothing; info = nothing; threw = false
+            try
+                (img, info) = render(make_n(n); strategy=strat, rkw..., ckw...)
+            catch err
+                threw = true
+                @info "render threw" sname cname resmode n err
+            end
+            @test !threw
+            threw && continue
+
+            # Valid RGB image with positive, info-consistent dimensions.
+            @test img isa Matrix{RGB{Float64}}
+            @test size(img, 1) > 0 && size(img, 2) > 0
+            @test size(img) == info.output_size
+            @test info.n_emitters_rendered == n
+            @test all(p -> isfinite(p.r) && isfinite(p.g) && isfinite(p.b), img)
+
+            if n == 0
+                # Empty input → spatially uniform (no spurious localized signal).
+                @test all(==(first(img)), img)
+                if cname === :intensity
+                    # Colormap zero (blank background), far below the previous
+                    # mid-colormap fill that wrongly painted empties solid.
+                    @test max(first(img).r, first(img).g, first(img).b) < 0.1
+                else
+                    # All other modes render an empty input as pure black.
+                    @test first(img) == RGB{Float64}(0.0, 0.0, 0.0)
+                end
+            end
+        end
+    end
+
 end


### PR DESCRIPTION
Combines the two independent fixes (previously #21 and #22) into a single **v0.4.6** release. Supersedes and auto-closes #21 and #22 (their commits are included here).

## 1. Empty / few-localization robustness (was #21)
`render()` crashed on a `BasicSMLD` with 0 (or coincident 1–2) localizations — `extrema`/`quantile` over empty values, and zero-span target bounds. Four reduction-site guards:
- `calculate_field_range` — isempty → default `(0.0, 1.0)` before reductions.
- `create_target_from_smld` (pixel_size) — isempty guard + 1-pixel min span (bounds unchanged for data spanning ≥1px).
- `normalize_to_01` / `apply_intensity_colormap` — all-zero input renders blank, not mid-fill.

A 0-loc input now yields a valid blank image; 1–2 locs render fine across all strategies × color modes, in zoom and pixel_size modes. Adds an "Empty and few-localization robustness" testset (n=0,1,2).

## 2. Categorical render perf (was #22)
`render_{ellipse,circle,gaussian}_categorical` rebuilt the categorical palette **per emitter**. Added a `palette` kwarg to `get_emitter_color(::CategoricalColorMapping)` (mirroring the field `lut`) and hoisted the build out of the loop. Output unchanged (palette is a pure function of its `Symbol`).

Benchmark (N=20000, 512×512, min of 30 runs, 1 thread):

| case | before | after | speedup | alloc |
|---|---|---|---|---|
| gaussian categorical | 56.98 ms | 22.64 ms | 2.5× | 47.8 → 21.0 MiB |
| circle categorical | 39.61 ms | 7.29 ms | 5.4× | 32.9 → 6.0 MiB |
| ellipse categorical | 42.49 ms | 10.55 ms | 4.0× | 32.9 → 6.0 MiB |

## Tests
Full suite **648/648 pass** (combined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)